### PR TITLE
Remove one of the duplicated "gitv" doc tags

### DIFF
--- a/doc/gitv.txt
+++ b/doc/gitv.txt
@@ -1,4 +1,4 @@
-*gitv* -- gitk for vim.
+gitv -- gitk for vim.
 
 AUTHOR:   Greg Sexton <gregsexton@gmail.com>                      *gitv-author*
 WEBSITE:  http://www.gregsexton.org/portfolio/gitv/


### PR DESCRIPTION
Having duplicated doc tags makes help generation fail.
