### PR TITLE
Prevent bdelete errors if buffer doesn't exist

### DIFF
--- a/plugin/gitv.vim
+++ b/plugin/gitv.vim
@@ -640,7 +640,9 @@ fu! s:RecordBufferExecAndWipe(cmd, wipe) "{{{
     if a:wipe
         "safe guard against wiping out buffer you're in
         if bufnr('%') != buf && bufexists(buf)
-            exec 'bdelete ' . buf
+            " ignore errors from bdelete -- the user won't care if it's
+            " already deleted
+            exec 'silent! bdelete ' . buf
         endif
     endif
 endfu "}}}


### PR DESCRIPTION
I ran into this error because I don't like closing the fugitive buffers manually (after Gdiff...). I found [this issue on fugitive](https://github.com/tpope/vim-fugitive/issues/81) where tpope recommends using an autocmd to clean up fugitive buffers. However, because gitv doesn't expect the fugitive buffers to disappear, it reports an error message. This change hides this error message with `silent!`.

You can easily reproduce this error you set fugitive buffers to auto-delete on close:

```
autocmd BufReadPost fugitive://* set bufhidden=delete
```

I figure that it's okay to ignore the error because we're closing windows as magic in the background to make sure that the buffer list isn't polluted with all the fugitive windows we open, so it's okay if the buffer was already deleted.

There is another bdelete in `s:OpenBrowserMode`, but it should be fine since it's just closing the preview that should have been just opened.
