### PR TITLE
Respect the user's foldlevelstart settings

### DIFF
--- a/plugin/gitv.vim
+++ b/plugin/gitv.vim
@@ -123,7 +123,6 @@ fu! Gitv_OpenGitCommand(command, windowCmd, ...) "{{{
             silent setlocal nowrap
         endif
         silent setlocal fdm=syntax
-        silent setlocal foldlevel=0
         nnoremap <buffer> <silent> q :q!<CR>
         nnoremap <buffer> <silent> u :if exists('b:Git_Command')<bar>call Gitv_OpenGitCommand(b:Git_Command, '', 1)<bar>endif<cr>
         call append(0, split(result, '\n')) "system converts eols to \n regardless of os.


### PR DESCRIPTION
I have `set foldlevelstart=99` in my `.vimrc` because I like to have folding enabled but I also want to start with all my folds open.
This commit removes the line that closes all folds by default.
