### PR TITLE
Use Ctrl-n/p to navigate revisions

### DIFF
--- a/plugin/gitv.vim
+++ b/plugin/gitv.vim
@@ -446,6 +446,8 @@ fu! s:AddFileModeSpecific(filePath, range, commitCount) "{{{
 endfu "}}}
 fu! s:SetupMappings() "{{{
     "operations
+    nnoremap <buffer> <silent> <C-n> <C-n>:call <SID>OpenGitvCommit("Gedit", 0)<cr>
+    nnoremap <buffer> <silent> <C-p> <C-p>:call <SID>OpenGitvCommit("Gedit", 0)<cr>
     nnoremap <buffer> <silent> <cr> :call <SID>OpenGitvCommit("Gedit", 0)<cr>
     nnoremap <buffer> <silent> o :call <SID>OpenGitvCommit("Gsplit", 0)<cr>
     nnoremap <buffer> <silent> O :call <SID>OpenGitvCommit("Gtabedit", 0)<cr>


### PR DESCRIPTION
Map C-n/C-p to navigate down/up through revisions. Moves down/up through
the list of revisions (in file and browser mode) and loads that
revision. Can be very useful to see changes in a file. (Unfortunately,
it doesn't keep you at the same point in the file, which would we even
better.)
