### PR TITLE
Add fold marker to start of the ToggleArg function

### DIFF
--- a/plugin/gitv.vim
+++ b/plugin/gitv.vim
@@ -251,7 +251,7 @@ fu! s:LoadGitv(direction, reload, commitCount, extraArgs, filePath, range) "{{{
     echom "Loaded up to " . a:commitCount . " commits."
     return 1
 endf "}}}
-fu! s:ToggleArg(args, toggle)
+fu! s:ToggleArg(args, toggle) "{{{
     if matchstr(a:args, a:toggle) == ''
       let NewArgs = a:args . ' ' . a:toggle
     else


### PR DESCRIPTION
This function was added in commit 392cd6f with a fold marker at the end
but not at the start, messing up the folding.
