### PR TITLE
Add dependency information for vim-addon-manager

### DIFF
--- a/addon-info.json
+++ b/addon-info.json
@@ -1,0 +1,5 @@
+{
+	"dependencies": {
+		"fugitive": {}
+	}
+}


### PR DESCRIPTION
This allows automatic installation of fugitive when using vim-addon-manager.