### PR TITLE
On unix, "+ is only supported with xterm_clipboard

### DIFF
--- a/plugin/gitv.vim
+++ b/plugin/gitv.vim
@@ -496,7 +496,11 @@ fu! s:SetupMappings() "{{{
     "misc
     nnoremap <buffer> git :Git<space>
     " yank the commit hash
-    nnoremap <buffer> <silent> yc m'$F[w"+yw`'
+    if !has('unix') || has('xterm_clipboard')
+        nnoremap <buffer> <silent> yc m'$F[w"+yw`'
+    else
+        nnoremap <buffer> <silent> yc m'$F[wyw`'
+    endif
 endf "}}}
 fu! s:SetupBufferCommands(fileMode) "{{{
     silent command! -buffer -nargs=* -complete=customlist,s:fugitive_GitComplete Git call <sid>MoveIntoPreviewAndExecute("unsilent Git <args>",1)|normal u


### PR DESCRIPTION
If you're on unix, but you don't have xterm_clipboard, you may want to
copy the hash for use within vim (in the unnamed register). Since
xterm_clipboard is irrelevant on non-unix, don't change behavior in that
case.

Fixes #48.
