### PR TITLE
Fix error in JumpToCommit

### DIFF
--- a/plugin/gitv.vim
+++ b/plugin/gitv.vim
@@ -1008,7 +1008,7 @@ endf "}}}
 fu! s:JumpToCommit(backwards) "{{{
     let flags = 'W'
     if a:backwards
-        let flags += 'b'
+        let flags .= 'b' 
     endif
 
     let c = v:count1


### PR DESCRIPTION
This fixes the "Invalid Argument" error generated if you try to use C-p
to go back up a commit in Browser view as of e9b71cca44.

I'm not sure if this was tested against an old version, but at least in
my version of vim (7.3 Mar 25 2013) the operator to concatenate strings is '.=', not
'+='
