### PR TITLE
Add command to jump to parent commit

### DIFF
--- a/doc/gitv.txt
+++ b/doc/gitv.txt
@@ -269,6 +269,10 @@ around a repository history in the browser window.
 
     normal      P       Jumps the cursor to the commit referenced by HEAD.
 
+    normal      p       Jumps the cursor to the commit which is the parent of
+                        current line.  When on a merge commit, a |count|
+                        may be used to choose a parent other than the first.
+
 3.5 Commands
 
 Running the |:Git| command in the commit browser window, in either mode, will

--- a/plugin/gitv.vim
+++ b/plugin/gitv.vim
@@ -476,6 +476,7 @@ fu! s:SetupMappings() "{{{
     nnoremap <buffer> <silent> r :call <SID>JumpToRef(0)<cr>
     nnoremap <buffer> <silent> R :call <SID>JumpToRef(1)<cr>
     nnoremap <buffer> <silent> P :call <SID>JumpToHead()<cr>
+    nnoremap <buffer> <silent> p :<c-u>call <SID>JumpToParent()<cr>
 
     "misc
     nnoremap <buffer> git :Git<space>
@@ -525,6 +526,18 @@ fu! s:GetGitvRefs(line) "{{{
     let refstr = matchstr(l, "^\\(\\(|\\|\\/\\|\\\\\\|\\*\\)\\s\\?\\)*\\s\\+(\\zs.\\{-}\\ze)")
     let refs = split(refstr, ', ')
     return refs
+endf "}}}
+fu! s:GetParentSha(sha, parentNum) "{{{
+    if a:parentNum < 1
+        return
+    endif
+    let hashCmd = "git log -n1 --pretty=format:%p " . a:sha
+    let [result,cmd] = s:RunGitCommand(hashCmd, 1)
+    let parents=split(result, ' ')
+    if a:parentNum > len(parents)
+        return
+    endif
+    return parents[a:parentNum-1]
 endf "}}}
 fu! s:GetConfirmString(list, ...) "{{{ {{{
     "returns a string to be used with confirm out of the choices in a:list
@@ -1019,6 +1032,21 @@ fu! s:JumpToCommit(backwards) "{{{
 
     redraw
     call s:OpenGitvCommit("Gedit", 0)
+endf "}}}
+fu! s:JumpToParent() "{{{
+    let sha = s:GetGitvSha(line('.'))
+    if sha == ""
+        return
+    endif
+    let parent = s:GetParentSha(sha, v:count1 )
+    if parent == ""
+        echom 'Parent '.v:count1.' is out of range'
+        return
+    endif
+    while !search( '^\ze.*\['.parent.'\]$', 'Ws' )
+        call s:LoadGitv('', 1, b:Gitv_CommitCount+g:Gitv_CommitStep, b:Gitv_ExtraArgs, s:GetRelativeFilePath(), s:GetRange())
+    endwhile
+    redraw
 endf "}}}
 "}}} }}}
 "Align And Truncate Functions: "{{{


### PR DESCRIPTION
Map the "p" key to make it easy to jump to a parent of the current
commit, even if there are many intervening commits on other branches,
loading enough of the history to include the target commit.  Allow a
count to be used to specify a parent other than the first for merge
commits.
