### PR TITLE
Use + register for yc on Mac OS X as well

### DIFF
--- a/plugin/gitv.vim
+++ b/plugin/gitv.vim
@@ -482,7 +482,7 @@ fu! s:SetupMappings() "{{{
     "misc
     nnoremap <buffer> git :Git<space>
     " yank the commit hash
-    if !has('unix') || has('xterm_clipboard')
+    if has('mac') || !has('unix') || has('xterm_clipboard')
         nnoremap <buffer> <silent> yc m'$F[w"+yw`'
     else
         nnoremap <buffer> <silent> yc m'$F[wyw`'


### PR DESCRIPTION
vim returns true for has('unix') on OS X and the has('xterm_clipboard')
returns false. But the + register works fine on OS X all the time, so add
an additional test to ensure that we enable the + register mapping all the
time on OS X.
