### PR TITLE
Add Plug for ctrl mappings

### DIFF
--- a/plugin/gitv.vim
+++ b/plugin/gitv.vim
@@ -444,15 +444,22 @@ fu! s:SetupMappings() "{{{
     nnoremap <buffer> <silent> o :call <SID>OpenGitvCommit("Gsplit", 0)<cr>
     nnoremap <buffer> <silent> O :call <SID>OpenGitvCommit("Gtabedit", 0)<cr>
     nnoremap <buffer> <silent> s :call <SID>OpenGitvCommit("Gvsplit", 0)<cr>
+
+    nnoremap <buffer> <silent> <Plug>(gitv-previous-commit) :<C-U>call <SID>JumpToCommit(0)<cr>
+    nnoremap <buffer> <silent> <Plug>(gitv-next-commit) :<C-U>call <SID>JumpToCommit(1)<cr>
+    "fuzzyfinder style key mappings
+    nnoremap <buffer> <silent> <Plug>(gitv-split) :call <SID>OpenGitvCommit("Gsplit", 0)<cr>
+    nnoremap <buffer> <silent> <Plug>(gitv-vsplit) :call <SID>OpenGitvCommit("Gvsplit", 0)<cr>
+    nnoremap <buffer> <silent> <Plug>(gitv-tabedit) :call <SID>OpenGitvCommit("Gtabedit", 0)<cr>
+    "force opening the fugitive buffer for the commit
+    nnoremap <buffer> <silent> <Plug>(gitv-edit) :call <SID>OpenGitvCommit("Gedit", 1)<cr>
     if(!exists("g:Gitv_DoNotMapCtrlKey"))
-        nnoremap <buffer> <silent> <C-n> :<C-U>call <SID>JumpToCommit(0)<cr>
-        nnoremap <buffer> <silent> <C-p> :<C-U>call <SID>JumpToCommit(1)<cr>
-        "fuzzyfinder style key mappings
-        nnoremap <buffer> <silent> <c-j> :call <SID>OpenGitvCommit("Gsplit", 0)<cr>
-        nnoremap <buffer> <silent> <c-k> :call <SID>OpenGitvCommit("Gvsplit", 0)<cr>
-        nnoremap <buffer> <silent> <c-l> :call <SID>OpenGitvCommit("Gtabedit", 0)<cr>
-        "force opening the fugitive buffer for the commit
-        nnoremap <buffer> <silent> <c-cr> :call <SID>OpenGitvCommit("Gedit", 1)<cr>
+        nmap <buffer> <silent> <C-n> <Plug>(gitv-previous-commit)
+        nmap <buffer> <silent> <C-p> <Plug>(gitv-next-commit)
+        nmap <buffer> <silent> <c-j> <Plug>(gitv-split)
+        nmap <buffer> <silent> <c-k> <Plug>(gitv-vsplit)
+        nmap <buffer> <silent> <c-l> <Plug>(gitv-tabedit)
+        nmap <buffer> <silent> <c-cr> <Plug>(gitv-edit)
     endif
     "for the terminal
     nnoremap <buffer> <silent> i :call <SID>OpenGitvCommit("Gedit", 1)<cr>

--- a/plugin/gitv.vim
+++ b/plugin/gitv.vim
@@ -400,14 +400,14 @@ fu! s:AddLocalNodes(filePath) "{{{
     let headLine = search('^\(\(|\|\/\|\\\|\*\)\s\?\)*\s*([^)]*HEAD', 'cnw')
     let headLine = headLine == 0 ? 1 : headLine
     if result != ""
-	let line = s:AlignWithRefs(headLine, s:localUncommitedMsg)
+        let line = s:AlignWithRefs(headLine, s:localUncommitedMsg)
         call append(headLine-1, substitute(line, '*', '=', ''))
         let headLine += 1
     endif
     let gitCmd = "diff --no-color --cached" . suffix
     let [result, cmd] = s:RunGitCommand(gitCmd, 0)
     if result != ""
-	let line = s:AlignWithRefs(headLine, s:localCommitedMsg)
+        let line = s:AlignWithRefs(headLine, s:localCommitedMsg)
         call append(headLine-1, substitute(line, '*', '+', ''))
     endif
 endfu
@@ -415,12 +415,12 @@ fu! s:AlignWithRefs(targetLine, targetStr)
     "returns the targetStr prefixed with enough whitespace to align with
     "the first asterisk on targetLine
     if a:targetLine == 0
-	return '*  '.a:targetStr
+        return '*  '.a:targetStr
     endif
     let line = getline(a:targetLine)
     let idx = stridx(line, '(')
     if idx == -1
-	return '*  '.a:targetStr
+        return '*  '.a:targetStr
     endif
     return strpart(line, 0, idx) . a:targetStr
 endfu "}}}
@@ -1151,4 +1151,4 @@ endfunction "}}} }}}
 let &cpo = s:savecpo
 unlet s:savecpo
 
- " vim:fdm=marker
+ " vim:set et sw=4 ts=4 fdm=marker:


### PR DESCRIPTION
17f084a53082be7b261be5a7cf97c95c36622bfe prevented me from using the Ctrl-p/n maps that I like, so I made them Plug mappings that can be defined in a user's ~/.vim/after/ftplugin/gitv.vim

Also updated the modeline to match your whitespace settings and fixed a few indentation lines that didn't match the rest of the file. (I left the fugitive lines alone since they're copied straight from fugitive.)
