### PR TITLE
Move some util functions into autoload space...

### DIFF
--- a/autoload/gitv/util/line.vim
+++ b/autoload/gitv/util/line.vim
@@ -1,0 +1,21 @@
+" Gitv line-related utility functions
+
+if exists('g:autoloaded_gitv_util_line')
+    finish
+endif
+let g:autoloaded_gitv_util_line = 1
+
+fu! gitv#util#line#sha(lineNumber) "{{{
+    let l = getline(a:lineNumber)
+    let sha = matchstr(l, "\\[\\zs[0-9a-f]\\{7}\\ze\\]$")
+    return sha
+endf "}}}
+
+fu! gitv#util#line#refs(line) "{{{
+    let l = getline(a:line)
+    let refstr = matchstr(l, "^\\(\\(|\\|\\/\\|\\\\\\|\\*\\)\\s\\?\\)*\\s\\+(\\zs.\\{-}\\ze)")
+    let refs = split(refstr, ', ')
+    return refs
+endf "}}}
+
+ " vim:set et sw=4 ts=4 fdm=marker:

--- a/plugin/gitv.vim
+++ b/plugin/gitv.vim
@@ -550,17 +550,6 @@ fu! s:ResizeWindow(fileMode) "{{{
     endif
 endf "}}} }}}
 "Utilities:"{{{
-fu! s:GetGitvSha(lineNumber) "{{{
-    let l = getline(a:lineNumber)
-    let sha = matchstr(l, "\\[\\zs[0-9a-f]\\{7}\\ze\\]$")
-    return sha
-endf "}}}
-fu! s:GetGitvRefs(line) "{{{
-    let l = getline(a:line)
-    let refstr = matchstr(l, "^\\(\\(|\\|\\/\\|\\\\\\|\\*\\)\\s\\?\\)*\\s\\+(\\zs.\\{-}\\ze)")
-    let refs = split(refstr, ', ')
-    return refs
-endf "}}}
 fu! s:GetParentSha(sha, parentNum) "{{{
     if a:parentNum < 1
         return
@@ -834,7 +823,7 @@ fu! s:OpenGitvCommit(geditForm, forceOpenFugitive) "{{{
         endif
         return
     endif
-    let sha = s:GetGitvSha(line('.'))
+    let sha = gitv#util#line#sha(line('.'))
     if sha == ""
         return
     endif
@@ -888,8 +877,8 @@ fu! s:EditRange(rangeDelimiter)
     return 1
 endfu "}}}
 fu! s:CheckOutGitvCommit() "{{{
-    let allrefs = s:GetGitvRefs('.')
-    let sha = s:GetGitvSha(line('.'))
+    let allrefs = gitv#util#line#refs('.')
+    let sha = gitv#util#line#sha(line('.'))
     if sha == ""
         return
     endif
@@ -935,8 +924,8 @@ fu! s:DiffGitvCommit() range "{{{
         echom "Diffing is not possible in browser mode."
         return
     endif
-    let shafirst = s:GetGitvSha(a:firstline)
-    let shalast  = s:GetGitvSha(a:lastline)
+    let shafirst = gitv#util#line#sha(a:firstline)
+    let shalast  = gitv#util#line#sha(a:lastline)
     if shafirst == "" || shalast == ""
         return
     endif
@@ -950,8 +939,8 @@ fu! s:MergeBranches() range "{{{
         echom 'Already up to date.'
         return
     endif
-    let refs = s:GetGitvRefs(a:firstline)
-    let refs += s:GetGitvRefs(a:lastline)
+    let refs = gitv#util#line#refs(a:firstline)
+    let refs += gitv#util#line#refs(a:lastline)
     call filter(refs, 'v:val !=? "HEAD"')
     if len(refs) < 2
         echom 'Not enough refs found to perform a merge.'
@@ -994,7 +983,7 @@ fu! s:PerformMerge(target, mergeBranch, ff) abort
     endif
 endfu
 fu! s:MergeToCurrent()
-    let refs = s:GetGitvRefs(".")
+    let refs = gitv#util#line#refs(".")
     call filter(refs, 'v:val !=? "HEAD"')
     if len(refs) < 1
         echoerr 'No ref found to perform a merge.'
@@ -1011,8 +1000,8 @@ fu! s:MergeToCurrent()
     call s:PerformMerge("HEAD", target, ff)
 endfu "}}}
 fu! s:StatGitvCommit() range "{{{
-    let shafirst = s:GetGitvSha(a:firstline)
-    let shalast  = s:GetGitvSha(a:lastline)
+    let shafirst = gitv#util#line#sha(a:firstline)
+    let shalast  = gitv#util#line#sha(a:lastline)
     if shafirst == "" || shalast == ""
         return
     endif
@@ -1068,7 +1057,7 @@ fu! s:JumpToCommit(backwards) "{{{
     call s:OpenGitvCommit("Gedit", 0)
 endf "}}}
 fu! s:JumpToParent() "{{{
-    let sha = s:GetGitvSha(line('.'))
+    let sha = gitv#util#line#sha(line('.'))
     if sha == ""
         return
     endif


### PR DESCRIPTION
...so that we may access and use them directly outside the plugin itself, w/o
incurring unnecessary load or other penalties.

```
s:GetGitvRefs() => gitv#util#line#refs()
```

   s:GetGitvSha()  => gitv#util#line#sha()
