### PR TITLE
Ability to perform bisect

### DIFF
--- a/doc/gitv.txt
+++ b/doc/gitv.txt
@@ -116,6 +116,8 @@ section: "Commit Limiting".
 
     --all             View repository history for all refs.
 
+    --bisect          If a bisect is started, show only the remaining commits.
+
     <since>..<until>  Show only commits between the named two commits. When
                       either <since> or <until> is omitted, it defaults to
                       HEAD, i.e. the tip of the current branch. For a more
@@ -288,6 +290,44 @@ around a repository history in the browser window.
                         current line.  When on a merge commit, a |count|
                         may be used to choose a parent other than the first.
 
+Here is a list of mappings for bisecting.
+
+    Mode        Map     Description~
+
+    normal      gbs     Begin the bisecting process. If the bisecting process
+                        has been started elsewhere, merely enables bisect mode.
+                        If the bisecting process has already been enabled,
+                        disables bisecting mode.
+                        Works in both modes.
+                        Mnemonic- git bisect start/git bisect stop.
+
+    visual      gbs     Same as normal mode, but if the bisecting process has
+                        not yet been started, marks the first commit selected
+                        as bad and the last commit selected as good.
+
+    normal      gbg     Mark the commit under the cursor as good.
+
+    visual      gbg     Mark selected commits as good.
+
+    normal      gbb     Mark the commit under the cursor as bad.
+
+    visual      gbb     Mark selected commits as bad.
+
+    normal      gbn     Skip the commit under the cursor. Accepts a count. If
+                        a count is given, ignores the commit under the cursor
+                        and starts at the currently checked out commit.
+                        Mnemonic- git bisect next.
+
+    visual      gbn     Skip the selected range of commits.
+
+    normal      gbr     End the bisect process. Mnemonic- git bisect reset.
+
+    normal      gbl     Save the current bisect history to a file. Edit the log
+                        file to correct mistakes and replay later.
+                        Mnemonic- git bisect log.
+
+    normal      gbp     Replay a saved log file.
+
 3.5 Commands
 
 Running the |:Git| command in the commit browser window, in either mode, will
@@ -457,6 +497,14 @@ losing functionality. The default is to create the mappings.
 >
     let g:Gitv_DoNotMapCtrlKey = 1
 >
+
+4.9 Do not log bisect actions.
+
+If this is set then no bisect mappings will log their actions. This will
+prevent the need to press enter after every bisect action, but could cause
+confusion. Errors will still be show.
+>
+    let g:Gitv_QuietBisect = 1
 
 ==============================================================================
 5. Changelog                                                *gitv-changelog*

--- a/plugin/gitv.vim
+++ b/plugin/gitv.vim
@@ -163,6 +163,10 @@ fu! s:OpenGitv(extraArgs, fileMode, rangeStart, rangeEnd) "{{{
     if sanitizedArgs[0] =~ "[\"']" && sanitizedArgs[:-1] =~ "[\"']"
         let sanitizedArgs = sanitizedArgs[1:-2]
     endif
+    if match(sanitizedArgs, ' --bisect') >= 0
+        let sanitizedArgs = substitute(' --bisect', '', 'g')
+        let b:Bisecting = 1
+    endif
     let g:Gitv_InstanceCounter += 1
     if !s:IsCompatible() "this outputs specific errors
         return

--- a/plugin/gitv.vim
+++ b/plugin/gitv.vim
@@ -1036,12 +1036,12 @@ fu! s:BisectLog() "{{{
     endif
     let fname = input('Enter a filename to save the log to: ')
     if filewritable(fname) != 1
-        throw 'Cannot write to file: ' . fname
+        echoerr 'Cannot write to file: ' . fname
         return
     endif
     let result = split(s:RunGitCommand('bisect log', 0)[0], '\n')
     if v:shell_error
-        throw result[0]
+        echoerr result[0]
         return
     endif
     call writefile(result, fname)
@@ -1049,12 +1049,12 @@ endf "}}}
 fu! s:BisectReplay() "{{{
     let fname = input('Enter a filename to replay: ')
     if !filereadable(fname)
-        throw 'Cannot read from file: ' . fname
+        echoerr 'Cannot read from file: ' . fname
         return
     endif
     let result = split(s:RunGitCommand('bisect replay ' . fname, 0)[0], '\n')
     if v:shell_error
-        throw result[0]
+        echoerr result[0]
         return
     endif
     let b:Bisecting = 1

--- a/plugin/gitv.vim
+++ b/plugin/gitv.vim
@@ -1058,11 +1058,8 @@ fu! s:BisectGoodBad(goodbad) range "{{{
 endf "}}}
 fu! s:BisectSkip(mode) range "{{{
     if exists('b:Bisecting') && s:BisectHasStarted()
-        if a:mode == 'n'
+        if a:mode == 'n' && v:count
             let loops = abs(v:count)
-            if loops == 0
-                let loops = 1
-            endif
             let loop = 0
             let errors = 0
             while loop < loops
@@ -1079,7 +1076,7 @@ fu! s:BisectSkip(mode) range "{{{
             if errors == loops
                 return
             endif
-        else "visual mode
+        else "visual mode or no range
             let cmd = 'bisect skip '
             let refs = s:GetGitvSha(a:lastline)
             if a:firstline != a:lastline

--- a/plugin/gitv.vim
+++ b/plugin/gitv.vim
@@ -1038,11 +1038,7 @@ fu! s:BisectLog() "{{{
     if !s:BisectHasStarted()
         return
     endif
-    let fname = input('Enter a filename to save the log to: ')
-    if filewritable(fname) != 1
-        echoerr 'Cannot write to file: ' . fname
-        return
-    endif
+    let fname = input('Enter a filename to save the log to: ', '', 'file')
     let result = split(s:RunGitCommand('bisect log', 0)[0], '\n')
     if v:shell_error
         echoerr result[0]
@@ -1051,11 +1047,7 @@ fu! s:BisectLog() "{{{
     call writefile(result, fname)
 endf "}}}
 fu! s:BisectReplay() "{{{
-    let fname = input('Enter a filename to replay: ')
-    if !filereadable(fname)
-        echoerr 'Cannot read from file: ' . fname
-        return
-    endif
+    let fname = input('Enter a filename to replay: ', '', 'file')
     let result = split(s:RunGitCommand('bisect replay ' . fname, 0)[0], '\n')
     if v:shell_error
         echoerr result[0]

--- a/plugin/gitv.vim
+++ b/plugin/gitv.vim
@@ -260,6 +260,20 @@ fu! s:LoadGitv(direction, reload, commitCount, extraArgs, filePath, range) "{{{
     echom "Loaded up to " . a:commitCount . " commits."
     return 1
 endf "}}}
+fu! s:DisableArg(args, disable) "{{{
+    if matchstr(a:args, a:disable) != ''
+      let NewArgs = substitute(a:args, ' ' . a:disable, '', '')
+    endif
+    let b:Gitv_ExtraArgs = NewArgs
+    return NewArgs
+endf "}}}
+fu! s:SanitizeArgs(args, sanitize) "{{{
+    let newArgs = a:args
+    for arg in a:sanitize
+        let newArgs = substitute(newArgs, ' ' . arg, '', 'g')
+    endfor
+    return newArgs
+endf "}}}
 fu! s:ToggleArg(args, toggle) "{{{
     if matchstr(a:args, a:toggle) == ''
       let NewArgs = a:args . ' ' . a:toggle
@@ -272,17 +286,24 @@ endf "}}}
 fu! s:ConstructAndExecuteCmd(direction, commitCount, extraArgs, filePath, range) "{{{
     if a:range == [] "no range, setup and execute the command
         let cmd  = "log " 
+        let extraArgs = a:extraArgs
+        if exists('b:Bisecting')
+            let cmd .= " --bisect"
+            let extraArgs = s:SanitizeArgs(extraArgs, ['--all', '--first-parent'])
+        endif
         let cmd .= " --no-color --decorate=full --pretty=format:\"%d %s__SEP__%ar__SEP__%an__SEP__[%h]\" --graph -"
         let cmd .= a:commitCount
-        let cmd .= " " . a:extraArgs
+        let cmd .= " " . extraArgs
         if a:filePath != ''
             let cmd .= ' -- ' . a:filePath
         endif
+        let g:cmd = cmd
         silent let res = Gitv_OpenGitCommand(cmd, a:direction)
         return res
     else "range applies, setup a trivial buffer and then modify it with custom logic
         let cmd = "--version" "arbitrary command intended to setup the buffer
                               "and act as a check everything is ok
+        let g:cmd = cmd
         silent let res = Gitv_OpenGitCommand(cmd, a:direction)
         if !res | return res | endif
         silent let res = s:ConstructRangeBuffer(a:commitCount, a:extraArgs, a:filePath, a:range)
@@ -296,7 +317,15 @@ fu! s:ConstructRangeBuffer(commitCount, extraArgs, filePath, range) "{{{
     %delete
 
     "necessary as order is important; can't just iterate over keys(slices)
-    let hashCmd       = "log " . a:extraArgs
+    let hashCmd       = "log "
+    let extraArgs = a:extraArgs
+    if exists('b:Bisecting')
+        let extraArgs = s:SanitizeArgs(extraArgs, ['--all', '--first-parent'])
+        let hashCmd .= extraArgs
+        let cmd .= " --bisect"
+    else
+        let hashCmd = . extraArgs
+    endif
     let hashCmd      .= " --no-color --pretty=format:%H -".a:commitCount." -- " . a:filePath
     let [result, cmd] = s:RunGitCommand(hashCmd, 0)
     let hashes        = split(result, '\n')
@@ -330,6 +359,14 @@ fu! s:GetFileSlices(range, filePath, commitCount, extraArgs) "{{{
     let range     = substitute(range, "'", "'\\\\''", 'g') "force unix style escaping even on windows
     let git       = fugitive#buffer().repo().git_command()
     let sliceCmd  = "for hash in `".git." log " . a:extraArgs
+    let extraArgs = a:extraArgs
+    if exists('b:Bisecting')
+        let extraArgs = s:SanitizeArgs(extraArgs, ['--all', '--first-parent'])
+        let cmd .= extraArgs
+        let cmd .= " --bisect"
+    else
+        let cmd = . extraArgs
+    endif
     let sliceCmd .= " --no-color --pretty=format:%H -".a:commitCount." -- " . a:filePath . '`; '
     let sliceCmd .= "do "
     let sliceCmd .= 'echo "****${hash}"; '
@@ -380,7 +417,11 @@ fu! s:GetFinalOutputForHashes(hashes) "{{{
         let git       = fugitive#buffer().repo().git_command()
         let cmd       = 'for hash in ' . join(a:hashes, " ") . '; '
         let cmd      .= "do "
-        let cmd      .= git.' log --no-color --decorate=full --pretty=format:"%d %s__SEP__%ar__SEP__%an__SEP__[%h]%n" --graph -1 ${hash}; '
+        let cmd      .= git.' log'
+        if exists('b:Bisecting')
+            let cmd .= " --bisect"
+        endif
+        let cmd      .='--no-color --decorate=full --pretty=format:"%d %s__SEP__%ar__SEP__%an__SEP__[%h]%n" --graph -1 ${hash}; '
         let cmd      .= 'done'
         let finalCmd  = "bash -c " . shellescape(cmd)
 
@@ -514,6 +555,24 @@ fu! s:SetupMappings() "{{{
 
     nmap <buffer> <silent> d :call <SID>DeleteRef()<cr>
     vmap <buffer> <silent> d :call <SID>DeleteRef()<cr>
+
+    "bisect
+    nmap <buffer> <silent> gbs :call <SID>BisectStart('n')<cr>
+    vmap <buffer> <silent> gbs :call <SID>BisectStart('v')<cr>
+
+    nmap <buffer> <silent> gbg :call <SID>BisectGoodBad('good')<cr>
+    vmap <buffer> <silent> gbg :call <SID>BisectGoodBad('good')<cr>
+
+    nmap <buffer> <silent> gbb :call <SID>BisectGoodBad('bad')<cr>
+    vmap <buffer> <silent> gbb :call <SID>BisectGoodBad('bad')<cr>
+
+    nmap <buffer> <silent> gbn :call <SID>BisectSkip('n')<cr>
+    vmap <buffer> <silent> gbn :call <SID>BisectSkip('v')<cr>
+
+    nmap <buffer> <silent> gbr :call <SID>BisectReset()<cr>
+
+    nmap <buffer> <silent> gbl :call <SID>BisectLog()<cr>
+    nmap <buffer> <silent> gbp :call <SID>BisectReplay()<cr>
 
     "movement
     nnoremap <buffer> <silent> x :call <SID>JumpToBranch(0)<cr>
@@ -898,6 +957,109 @@ fu! s:EditRange(rangeDelimiter)
     call s:SetRange(idx, value)
     return 1
 endfu "}}}
+"Bisect: "{{{
+fu! s:BisectHasStarted() "{{{
+    call s:RunGitCommand('bisect log', 0)
+    return !v:shell_error
+endf "}}}
+fu! s:BisectStart(mode) range "{{{
+    if exists('b:Bisecting')
+        unlet! b:Bisecting
+    elseif !s:BisectHasStarted()
+        call s:RunGitCommand('bisect start', 0)[0]
+        if a:mode == 'v'
+            call s:RunGitCommand('bisect bad ' . s:GetGitvSha(a:firstline), 0)[0]
+            if a:firstline != a:lastline
+                call s:RunGitCommand('bisect good ' . s:GetGitvSha(a:lastline), 0)[0]
+            endif
+        endif
+        let b:Bisecting = 1
+    else
+        let b:Bisecting = 1
+    endif
+    call s:LoadGitv('', 1, b:Gitv_CommitCount, b:Gitv_ExtraArgs, s:GetRelativeFilePath(), s:GetRange())
+endf "}}}
+fu! s:BisectReset() "{{{
+    if exists('b:Bisecting')
+        unlet! b:Bisecting
+    endif
+    if s:BisectHasStarted()
+        call s:RunGitCommand('bisect reset', 0)
+    endif
+    call s:LoadGitv('', 1, b:Gitv_CommitCount, b:Gitv_ExtraArgs, s:GetRelativeFilePath(), s:GetRange())
+endf "}}}
+fu! s:BisectGoodBad(goodbad) range "{{{
+    let goodbad = a:goodbad . ' '
+    if exists('b:Bisecting') && s:BisectHasStarted()
+        if a:firstline == a:lastline
+            call s:RunGitCommand('bisect ' . goodbad . s:GetGitvSha('.'), 0)
+        else
+            let refs2 = s:GetGitvSha(a:firstline)
+            let refs1 = s:GetGitvSha(a:lastline)
+            let refs = refs1 . "^.." . refs2
+            let cmd = 'log --pretty=format:%h '
+            let refs = split(s:RunGitCommand(cmd . refs, 0)[0], '\n')
+            for ref in refs
+                call s:RunGitCommand('bisect ' . goodbad . ref, 0)
+            endfor
+        endif
+        call s:LoadGitv('', 1, b:Gitv_CommitCount, b:Gitv_ExtraArgs, s:GetRelativeFilePath(), s:GetRange())
+    endif
+endf "}}}
+fu! s:BisectSkip(mode) range "{{{
+    if exists('b:Bisecting') && s:BisectHasStarted()
+        if a:mode == 'n'
+            let loops = abs(v:count)
+            if loops == 0
+                let loops = 1
+            endif
+            while loops > 0
+                call s:RunGitCommand('bisect skip', 0)
+                let loops = loops - 1
+            endwhile
+        else "visual mode
+            let cmd = 'bisect skip '
+            let refs = ''
+            if a:firstline != a:lastline
+                let refs1 = s:GetGitvSha(a:lastline)
+                let refs2 = s:GetGitvSha(a:firstline)
+                let refs = refs1 . "^.." . refs2
+            endif
+            call s:RunGitCommand('bisect skip ' . refs, 0)
+        endif
+        call s:LoadGitv('', 1, b:Gitv_CommitCount, b:Gitv_ExtraArgs, s:GetRelativeFilePath(), s:GetRange())
+    endif
+endf "}}}
+fu! s:BisectLog() "{{{
+    if !s:BisectHasStarted()
+        return
+    endif
+    let fname = input('Enter a filename to save the log to: ')
+    if filewritable(fname) != 1
+        throw 'Cannot write to file: ' . fname
+        return
+    endif
+    let result = split(s:RunGitCommand('bisect log', 0)[0], '\n')
+    if v:shell_error
+        throw result[0]
+        return
+    endif
+    call writefile(result, fname)
+endf "}}}
+fu! s:BisectReplay() "{{{
+    let fname = input('Enter a filename to replay: ')
+    if !filereadable(fname)
+        throw 'Cannot read from file: ' . fname
+        return
+    endif
+    let result = split(s:RunGitCommand('bisect replay ' . fname, 0)[0], '\n')
+    if v:shell_error
+        throw result[0]
+        return
+    endif
+    let b:Bisecting = 1
+    call s:LoadGitv('', 1, b:Gitv_CommitCount, b:Gitv_ExtraArgs, s:GetRelativeFilePath(), s:GetRange())
+endf "}}} }}}
 fu! s:CheckOutGitvCommit() "{{{
     let allrefs = s:GetGitvRefs('.')
     let sha = s:GetGitvSha(line('.'))


### PR DESCRIPTION
Typing `gbs` starts bisect mode. It also can enable/disable it.
`--bisect` also enables bisect mode if it's available.
In bisect mode, shows the commits left within the bisect if a good commit and bad commit is given (just like the `--bisect` argument to `git log`).
`gbn` is `git bisect skip`, `gbg` is `git bisect good`, `gbb` is `git bisect bad`. All can select multiple commits in visual mode. `gbn` accepts a count.
`gbr` is `git bisect reset`.
`gbl` is `git bisect log`, `gbr` is `git bisect replay`. They have file completion.
`g:Gitv_QuietBisect` shuts it up, except for errors.
Works in both modes.
Documentation available.