### PR TITLE
Revert binding

### DIFF
--- a/doc/gitv.txt
+++ b/doc/gitv.txt
@@ -247,6 +247,12 @@ modes.
                           selected commits
     normal      rbh       same as visual rbh
 
+    normal      rev       Revert the commit. If the commit is a merge, selects
+                          the first parent for reverting to.
+
+    visual      rev       Same as rev, but revert a range of commits. If a
+                          merge is within the range, fails by necessity.
+
     visual      d         Delete a branch or tag on the selected line. You will
                           be asked which branch/tag to use.
     normal      d         same as visual d

--- a/plugin/gitv.vim
+++ b/plugin/gitv.vim
@@ -1062,7 +1062,6 @@ fu! s:Revert() range "{{{
     endif
     let cmd = 'revert --no-commit ' . mergearg . ' ' . refs
     let result = s:RunGitCommand(cmd, 0)[0]
-    let g:result = result
     if result != ''
         throw split(result)[0]
         return


### PR DESCRIPTION
`rev` reverts the commit under the cursor.
In visual mode, reverts a range.
If a merge commit is selected, selects the first parent (the original for the current ref).
If a merge is within a range, must fail.