### PR TITLE
Fix short sha length to be matched.

### DIFF
--- a/autoload/gitv/util/line.vim
+++ b/autoload/gitv/util/line.vim
@@ -7,7 +7,7 @@ let g:autoloaded_gitv_util_line = 1
 
 fu! gitv#util#line#sha(lineNumber) "{{{
     let l = getline(a:lineNumber)
-    let sha = matchstr(l, "\\[\\zs[0-9a-f]\\{7,9}\\ze\\]$")
+    let sha = matchstr(l, "\\[\\zs[0-9a-f]\\{7,10}\\ze\\]$")
     return sha
 endf "}}}
 


### PR DESCRIPTION
There is a sha of 10 digits. So make `gitv#util#line#sha()` correspond to 10 digits.

https://github.com/git/git/commit/e6c587c733b4634030b353f4024794b08bc86892
```
Currently the Linux kernel project needs 11 to 12 hexdigits, while
Git itself needs 10 hexdigits to uniquely identify the objects they
have, while many smaller projects may still be fine with the
original 7-hexdigit default.  One-size does not fit all projects.
```