### PR TITLE
Stop assuming abbreviated hash length

### DIFF
--- a/autoload/gitv/util/line.vim
+++ b/autoload/gitv/util/line.vim
@@ -7,7 +7,7 @@ let g:autoloaded_gitv_util_line = 1
 
 fu! gitv#util#line#sha(lineNumber) "{{{
     let l = getline(a:lineNumber)
-    let sha = matchstr(l, "\\[\\zs[0-9a-f]\\{7,10}\\ze\\]$")
+    let sha = matchstr(l, "\\[\\zs[0-9a-f]\\{7,40}\\ze\\]$")
     return sha
 endf "}}}
 


### PR DESCRIPTION
Git will always use at least 7 characters, but the size of the
abbreviated hash just scales with the repo size.  I am working on a repo
that abbreviates to 11, rather than up the length one more, let's just
go straight to 40. (I see no downsides)