### PR TITLE
Provide button to create and checkout new local branch for remote-onl…

### DIFF
--- a/plugin/gitv.vim
+++ b/plugin/gitv.vim
@@ -2260,26 +2260,23 @@ fu! s:CheckOutGitvCommit() "{{{
         return
     endif
 
-    " Add refs to create and checkout a new local branch for remote-only branches
-    let remoterefs = []
-    let localrefs = []
+    " Modify refs to create and checkout new local branch for remote-only branches
+    let newrefs = []
     for ref in allrefs
         if (match(ref, '^r:') == 0) || (match(ref, '^refs/remotes/') == 0)
-            let remoterefs += [ref]
+            " Remove remote part
+            let ref = substitute(ref, '^r:\(\w\+\)/\(.*\)', '\2', '')
+            let ref = substitute(ref, '^refs\/remotes\/\(\w\+\)/\(.*\)', '\2', '')
+            if count(allrefs, ref) == 0
+                " Prevent dublicates
+                let newrefs += [ref]
+            endif
         else
-            let localrefs += [ref]
-        endif
-    endfor
-    let newrefs = []
-    for remoteref in remoterefs
-        let ref = substitute(remoteref, '^r:\(\w\+\)/\(.*\)', '\2', '')
-        let ref = substitute(ref, '^refs\/remotes\/\(\w\+\)/\(.*\)', '\2', '')
-        if count(localrefs, ref) == 0
             let newrefs += [ref]
         endif
     endfor
 
-    let refs   = allrefs + newrefs + [sha]
+    let refs   = newrefs + [sha]
     let refstr = s:GetConfirmString(refs, 'Cancel')
     let choice = confirm("Checkout commit:", refstr)
     if choice == 0

--- a/plugin/gitv.vim
+++ b/plugin/gitv.vim
@@ -2259,7 +2259,24 @@ fu! s:CheckOutGitvCommit() "{{{
     if sha == ""
         return
     endif
-    let refs   = allrefs + [sha]
+
+    " Add refs to create and checkout a new branch for remote-only branches
+    let origrefs = []
+    for ref in allrefs
+        if match(ref, '^\(r:\)\|\(refs/remotes/\)origin/') == 0 && match(ref, '/HEAD$') == -1
+            let origrefs += [ref]
+        endif
+    endfor
+    let newrefs = []
+    for origref in origrefs
+        let ref = substitute(origref, '^r:origin/\(.*\)', '\1', '')
+        let ref = substitute(ref, '^refs/remotes/origin/\(.*\)', '\1', '')
+        if count(allrefs, ref) == 0
+            let newrefs += [ref]
+        endif
+    endfor
+
+    let refs   = allrefs + newrefs + [sha]
     let refstr = s:GetConfirmString(refs, 'Cancel')
     let choice = confirm("Checkout commit:", refstr)
     if choice == 0

--- a/plugin/gitv.vim
+++ b/plugin/gitv.vim
@@ -2260,18 +2260,20 @@ fu! s:CheckOutGitvCommit() "{{{
         return
     endif
 
-    " Add refs to create and checkout a new branch for remote-only branches
-    let origrefs = []
+    " Add refs to create and checkout a new local branch for remote-only branches
+    let remoterefs = []
+    let localrefs = []
     for ref in allrefs
-        if match(ref, '^\(r:\)\|\(refs/remotes/\)origin/') == 0 && match(ref, '/HEAD$') == -1
-            let origrefs += [ref]
+        if match(ref, '^r:') == 0
+            let remoterefs += [ref]
+        else
+            let localrefs += [ref]
         endif
     endfor
     let newrefs = []
-    for origref in origrefs
-        let ref = substitute(origref, '^r:origin/\(.*\)', '\1', '')
-        let ref = substitute(ref, '^refs/remotes/origin/\(.*\)', '\1', '')
-        if count(allrefs, ref) == 0
+    for remoteref in remoterefs
+        let ref = substitute(remoteref, '^r:\(\w\+\)/\(.*\)', '\2', '')
+        if count(localrefs, ref) == 0
             let newrefs += [ref]
         endif
     endfor

--- a/plugin/gitv.vim
+++ b/plugin/gitv.vim
@@ -2264,7 +2264,7 @@ fu! s:CheckOutGitvCommit() "{{{
     let remoterefs = []
     let localrefs = []
     for ref in allrefs
-        if match(ref, '^r:') == 0
+        if (match(ref, '^r:') == 0) || (match(ref, '^refs/remotes/') == 0)
             let remoterefs += [ref]
         else
             let localrefs += [ref]
@@ -2273,6 +2273,7 @@ fu! s:CheckOutGitvCommit() "{{{
     let newrefs = []
     for remoteref in remoterefs
         let ref = substitute(remoteref, '^r:\(\w\+\)/\(.*\)', '\2', '')
+        let ref = substitute(ref, '^refs\/remotes\/\(\w\+\)/\(.*\)', '\2', '')
         if count(localrefs, ref) == 0
             let newrefs += [ref]
         endif


### PR DESCRIPTION
I create new branches in bitbucket and fetch them locally. With this change I get a button to checkout this as local branch in gitv if I type `co` on the line containing the remote branch.