### PR TITLE
Replace Gcommit with Git commit

### DIFF
--- a/doc/gitv.txt
+++ b/doc/gitv.txt
@@ -567,7 +567,7 @@ Once rebasing mode is enabled, `grc` may do one of several things. If the
 rebasing instruction would normally trigger a commit, the fugitive commit
 window will automatically open. If you are not sure why the window has opened,
 please view the comments in the commit window. If the window is closed, it can
-always be reopened with `Gcommit`. gitv may also do nothing. This indicates
+always be reopened with `Git commit`. gitv may also do nothing. This indicates
 that you have a chance to edit the commit.
 
 You can continue with the rebase process at any interactive instruction with

--- a/plugin/gitv.vim
+++ b/plugin/gitv.vim
@@ -1989,9 +1989,9 @@ fu! s:RebaseContinueCleanup() "{{{
     endif
     if mode == 'r' || mode == 's'
         if mode == 'r'
-            Gcommit --amend
+            Git commit --amend
         else
-            Gcommit
+            Git commit
         endif
         set modifiable
         if &ft == 'gitcommit'
@@ -2453,7 +2453,7 @@ fu! s:Revert() range "{{{
         throw split(result, '\n')[0]
         return
     endif
-    exec 'Gcommit'
+    exec 'Git commit'
 endfu "}}}
 fu! s:DeleteRef() range "{{{
     let refs = gitv#util#line#refs(a:firstline)


### PR DESCRIPTION
`Gcommit` is deprecated in Fugitive.

```
Gcommit is deprecated in favor of :Git commit
```

This change replaces Gcommit with Git commit.